### PR TITLE
rename removeKey method. Document headers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/RSSecrets.h
+++ b/RSSecrets.h
@@ -71,7 +71,7 @@
  
  @param key     The key to remove
  
- @deprectated   Use removeObjectForKey: instead
+ @deprecated    Use removeObjectForKey: instead
  */
 + (void)removeKey:(NSString *)key __attribute__((deprecated));
 

--- a/RSSecrets.h
+++ b/RSSecrets.h
@@ -3,20 +3,20 @@
 //  Secrets
 //
 // Copyright (C) 2012, Jeff Argast. All rights reserved.
-// 
+//
 // The author make NO WARRANTY or representation, either express or implied,
 // with respect to this software, its quality, accuracy, merchantability, or
 // fitness for a particular purpose.  This software is provided "AS IS", and you,
 // its user, assume the entire risk as to its quality and accuracy.
-// 
+//
 // Permission is hereby granted to use, copy, modify, and distribute this
 // software or portions thereof for any purpose, without fee, subject to these
 // conditions:
-// 
+//
 // (1) If any part of the source code is distributed, then this
 // statement must be included, with this copyright and no-warranty notice
 // unaltered.
-// 
+//
 // (2) Permission for use of this software is granted only if the user accepts
 // full responsibility for any undesirable consequences; the author accepts
 // NO LIABILITY for damages of any kind.
@@ -24,14 +24,63 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ * Set and get encrypted values from the iOS keychain.
+ */
 @interface RSSecrets : NSObject
 
-+ (void) setData: (NSData*) object forKey: (NSString*) key;
-+ (void) setString: (NSString*) object forKey: (NSString*) key;
+/**
+ Adds a given key-value pair to the keychain.
+ 
+ @param data    The data value to set for _key_.
+ @param key     The key for _string_.
+ 
+ @discussion If an object for _key_ already exists in the keychain, _data_ takes its place.
+ */
++ (void)setData:(NSData *)data forKey:(NSString *)key;
 
-+ (NSData*) dataForKey: (NSString*) key;
-+ (NSString*) stringForKey: (NSString*) key;
+/**
+ Adds a given key-value pair to the keychain.
+ 
+ @param string  The string value to set for _key_.
+ @param key     The key for _string_.
+ 
+ @discussion If an object for _key_ already exists in the keychain, _string_ takes its place.
+ */
++ (void)setString:(NSString *)string forKey:(NSString *)key;
 
-+ (void) removeKey: (NSString*) key;
+
+/**
+ Returns the data value associated with a given key.
+ 
+ @param key     The key for which to return the corresponding value.
+ @return        The data associated with _key_, or `nil` if no value is associated with _key_.
+ */
++ (NSData *)dataForKey:(NSString *)key;
+
+/**
+ Returns the string value associated with a given key.
+ 
+ @param key     The key for which to return the corresponding value.
+ @return        The string associated with _key_, or `nil` if no value is associated with _key_.
+ */
++ (NSString *)stringForKey:(NSString *)key;
+
+/**
+ Remove the value for a key
+ 
+ @param key     The key to remove
+ 
+ @deprectated   Use removeObjectForKey: instead
+ */
++ (void)removeKey:(NSString *)key __attribute__((deprecated));
+
+
+/**
+ Remove the value for a key
+ 
+ @param key     The key to remove
+ */
++ (void)removeObjectForKey:(NSString *)key;
 
 @end

--- a/RSSecrets.m
+++ b/RSSecrets.m
@@ -4,20 +4,20 @@
 //
 //
 // Copyright (C) 2012, Jeff Argast. All rights reserved.
-// 
+//
 // The author make NO WARRANTY or representation, either express or implied,
 // with respect to this software, its quality, accuracy, merchantability, or
 // fitness for a particular purpose.  This software is provided "AS IS", and you,
 // its user, assume the entire risk as to its quality and accuracy.
-// 
+//
 // Permission is hereby granted to use, copy, modify, and distribute this
 // software or portions thereof for any purpose, without fee, subject to these
 // conditions:
-// 
+//
 // (1) If any part of the source code is distributed, then this
 // statement must be included, with this copyright and no-warranty notice
 // unaltered.
-// 
+//
 // (2) Permission for use of this software is granted only if the user accepts
 // full responsibility for any undesirable consequences; the author accepts
 // NO LIABILITY for damages of any kind.
@@ -27,53 +27,58 @@
 
 @implementation RSSecrets
 
-+ (void) setData: (NSData*) object forKey: (NSString*) key {	
-	NSMutableDictionary* dict = [NSMutableDictionary dictionary];
-
-	[dict setObject: (__bridge id) kSecClassGenericPassword forKey: (__bridge id) kSecClass];
-	[dict setObject: key forKey: (__bridge id) kSecAttrService];
-	
-	SecItemDelete((__bridge CFDictionaryRef) dict);
-
-	if (object) {
-		[dict setObject: object forKey: (__bridge id) kSecValueData];
-		SecItemAdd ((__bridge CFDictionaryRef) dict, NULL);
-	}
++ (void)setData:(NSData *)data forKey:(NSString *)key {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    
+    [dict setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+    [dict setObject:key forKey:(__bridge id)kSecAttrService];
+    
+    SecItemDelete((__bridge CFDictionaryRef)dict);
+    
+    if (data) {
+        [dict setObject:data forKey:(__bridge id)kSecValueData];
+        SecItemAdd((__bridge CFDictionaryRef)dict, NULL);
+    }
 }
 
-+ (NSData*) dataForKey: (NSString*) key {
-	NSMutableDictionary* query = [NSMutableDictionary dictionary];
-	[query setObject: (__bridge id) kSecClassGenericPassword forKey: (__bridge id) kSecClass];
-	[query setObject: key forKey: (__bridge id) kSecAttrService];
-	[query setObject: (id) kCFBooleanTrue forKey: (__bridge id) kSecReturnData];
-
-	CFTypeRef result = nil;
-	SecItemCopyMatching((__bridge CFDictionaryRef) query, &result);
-	if (!result)
-		return nil;
-
-	return (__bridge NSData*) result;
++ (NSData *)dataForKey:(NSString *)key {
+    NSMutableDictionary *query = [NSMutableDictionary dictionary];
+    
+    [query setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+    [query setObject:key forKey:(__bridge id)kSecAttrService];
+    [query setObject:(id)kCFBooleanTrue forKey:(__bridge id)kSecReturnData];
+    
+    CFTypeRef result = nil;
+    SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+    
+    if (!result) return nil;
+    
+    return (__bridge NSData *)result;
 }
 
-+ (void) setString: (NSString*) object forKey: (NSString*) key {	
-	[self setData: [object dataUsingEncoding: NSUTF8StringEncoding] forKey: key];
++ (void)setString:(NSString *)string forKey:(NSString *)key {
+    [self setData:[string dataUsingEncoding:NSUTF8StringEncoding] forKey:key];
 }
 
-+ (NSString*) stringForKey: (NSString*) key {
-	NSData* data = [self dataForKey: key]; 
-	if (!data)
-		return nil;
-	
-	return [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
++ (NSString *)stringForKey:(NSString *)key {
+    NSData *data = [self dataForKey:key];
+    
+    if (!data) return nil;
+    
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
-+ (void) removeKey: (NSString*) key {
-	NSMutableDictionary* dict = [NSMutableDictionary dictionary];
++ (void)removeKey:(NSString *)key {
+    [self removeObjectForKey:key];
+}
 
-	[dict setObject: (__bridge id) kSecClassGenericPassword forKey: (__bridge id) kSecClass];
-	[dict setObject: key forKey: (__bridge id) kSecAttrService];
-	
-	SecItemDelete((__bridge CFDictionaryRef) dict);
++ (void)removeObjectForKey:(NSString *)key {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    
+    [dict setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+    [dict setObject:key forKey:(__bridge id)kSecAttrService];
+    
+    SecItemDelete((__bridge CFDictionaryRef)dict);
 }
 
 @end


### PR DESCRIPTION
Hi - love the simplicity of this project! 

I do think that removeKey: is misleading, so I renamed it. I also documented the header using appledoc style, which can be used to easily generate documentation pages - see the output [here](http://ryanmaxwell.github.com/RSSecrets/). This is great as users who install the library via cocoapods will have the docset installed automatically!
